### PR TITLE
UTC Timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 dist
 /.project
 /.pydevproject
+*~

--- a/hookbox/admin/admin.py
+++ b/hookbox/admin/admin.py
@@ -7,7 +7,7 @@ import logging
 from hookbox.errors import ExpectedException
 import hookbox #for version info
 import cgi
-import datetime
+from hookbox.utils import get_now
 import eventlet
 
 
@@ -97,7 +97,7 @@ class HookboxAdminApp(object):
             "form": form_body and cgi.escape(str(form_body)),
             "cookie": cookie_string and cgi.escape(str(cookie_string)),
             "err": err and cgi.escape(str(err)),
-            "date": datetime.datetime.now().strftime("%A %d-%b-%y %H:%M:%S %Z")
+            "date": get_now(),
         }
         self.webhooks_history.append(frame)
         while len(self.webhooks_history) > WEBHOOK_HISTORY_SIZE:

--- a/hookbox/channel.py
+++ b/hookbox/channel.py
@@ -5,11 +5,7 @@ try:
     import json
 except ImportError:
     import simplejson as json
-import datetime
-
-def get_now():
-  return datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-
+from utils import get_now
 
 
 class Channel(object):

--- a/hookbox/user.py
+++ b/hookbox/user.py
@@ -4,10 +4,8 @@ try:
     import json
 except ImportError:
     import simplejson as json
-import datetime
+from utils import get_now
 
-def get_now():
-  return datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
 class User(object):
     _options = {

--- a/hookbox/utils.py
+++ b/hookbox/utils.py
@@ -1,0 +1,4 @@
+import datetime
+
+def get_now():
+  return datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')


### PR DESCRIPTION
Hookbox uses the server's local time which (IMO) makes working with international clients harder than necessary. Using UTC timestamps fixes that.
